### PR TITLE
implement rpm and debian installation on iRODS 4.2 and higher.

### DIFF
--- a/client/packaging/create_deb_package.sh
+++ b/client/packaging/create_deb_package.sh
@@ -75,7 +75,7 @@ Version: ${VERSION}-${RELEASE}
 Section: unknown
 Priority: optional
 Architecture: all
-Depends: irods-icat (>= 4.0.0)
+Depends: irods-icat (>= 4.0.0) | irods-server (>= 4.2.0) | irods-icommands (>= 4.2.0)
 Maintainer: Robert Verkerk <robert.verkerk@surfsara.nl>
 Description: B2SAFE DPM client for iRODS package
 B2SAFE DPM client are a set of scripts to implement policies in iRODS.
@@ -86,10 +86,14 @@ EOF
 cat > $RPM_BUILD_ROOT${PACKAGE}/DEBIAN/postinst << EOF
 #!/bin/bash
 # create symbolic links
-if [ -e "/var/lib/irods/iRODS/server/bin/cmd" ]
+IRODS_DIR=/var/lib/irods
+if [ -e "\${IRODS_DIR}/msiExecCmd_bin" ]
 then
-    ln -sf ${IRODS_PACKAGE_DIR}/cmd/PolicyManager.py /var/lib/irods/iRODS/server/bin/cmd/runPolicyManager.py
-fi
+  IRODS_LINK_DIR="\${IRODS_DIR}/msiExecCmd_bin"
+else
+  IRODS_LINK_DIR="\${IRODS_DIR}/iRODS/server/bin/cmd"
+fi 
+ln -sf ${IRODS_PACKAGE_DIR}/cmd/PolicyManager.py \${IRODS_LINK_DIR}/runPolicyManager.py
 
 # show package installation/configuration info 
 cat << EOF1
@@ -109,7 +113,7 @@ then
     source \$IRODS_SERVICE_ACCOUNT_CONFIG
     chown -R \$IRODS_SERVICE_ACCOUNT_NAME:\$IRODS_SERVICE_GROUP_NAME ${IRODS_PACKAGE_DIR} 
     chown -R \$IRODS_SERVICE_ACCOUNT_NAME:\$IRODS_SERVICE_GROUP_NAME /var/log/irods
-    chown -R \$IRODS_SERVICE_ACCOUNT_NAME:\$IRODS_SERVICE_GROUP_NAME /var/lib/irods/iRODS/server/bin/cmd/runPolicyManager.py
+    chown -R \$IRODS_SERVICE_ACCOUNT_NAME:\$IRODS_SERVICE_GROUP_NAME \${IRODS_LINK_DIR}/runPolicyManager.py
 fi
 
 EOF

--- a/client/packaging/irods-eudat-b2safe-dpm-client.spec
+++ b/client/packaging/irods-eudat-b2safe-dpm-client.spec
@@ -12,7 +12,7 @@ BuildArch:	noarch
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 #BuildRequires:	
-Requires:	irods-icat
+#Requires:	irods-icat
 
 %define _whoami %(whoami)
 %define _b2safehomepackaging %(pwd)
@@ -97,6 +97,10 @@ if [ -e "/var/lib/irods/iRODS/server/bin/cmd" ]
 then
     ln -sf %{_irodsPackage}/cmd/PolicyManager.py /var/lib/irods/iRODS/server/bin/cmd/runPolicyManager.py
 fi
+if [ -e "/var/lib/irods/msiExecCmd_bin" ]
+then
+    ln -sf %{_irodsPackage}/cmd/PolicyManager.py /var/lib/irods/msiExecCmd_bin/runPolicyManager.py
+fi
 # only show info on first installation
 if [ "$1" = "1" ]
 then 
@@ -120,7 +124,14 @@ then
     source $IRODS_SERVICE_ACCOUNT_CONFIG
     chown -R $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME %{_irodsPackage}
     chown -R $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/log/irods
-    chown -R $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/iRODS/server/bin/cmd/runPolicyManager.py
+    if [ -e "/var/lib/irods/iRODS/server/bin/cmd" ]
+    then
+       chown -R $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/iRODS/server/bin/cmd/runPolicyManager.py
+    fi
+    if [ -e "/var/lib/irods/msiExecCmd_bin" ]
+    then
+       chown -R $IRODS_SERVICE_ACCOUNT_NAME:$IRODS_SERVICE_GROUP_NAME /var/lib/irods/msiExecCmd_bin/runPolicyManager.py
+    fi
 fi
 
 
@@ -134,5 +145,7 @@ then
     fi
 fi
 %changelog
+* Thu Nov 30 2017  Robert Verkerk <robert.verkerk@surfsara.nl> 1.0-1
+- make sure it works on iRODS 4.2 and higher
 * Wed Aug 12 2015  Robert Verkerk <robert.verkerk@surfsara.nl> 1.0
 - Initial version of b2safe dpm client package


### PR DESCRIPTION
Tested creation of rpm and installation on Centos and iRODS 4.1.8:

```
# yum install  ./irods-eudat-b2safe-dpm-client-1.0-0.noarch.rpm
Loaded plugins: fastestmirror
Setting up Install Process
Examining /home/robertv/rpmbuild/RPMS/noarch/irods-eudat-b2safe-dpm-client-1.0-0.noarch.rpm: irods-eudat-b2safe-dpm-client-1.0-0.noarch
Marking /home/robertv/rpmbuild/RPMS/noarch/irods-eudat-b2safe-dpm-client-1.0-0.noarch.rpm to be installed
Loading mirror speeds from cached hostfile
 * epel: nl.mirror.babylon.network
Resolving Dependencies
--> Running transaction check
---> Package irods-eudat-b2safe-dpm-client.noarch 0:1.0-0 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

===========================================================================================================================================================
 Package                                      Arch                  Version               Repository                                                  Size
===========================================================================================================================================================
Installing:
 irods-eudat-b2safe-dpm-client                noarch                1.0-0                 /irods-eudat-b2safe-dpm-client-1.0-0.noarch                 94 k

Transaction Summary
===========================================================================================================================================================
Install       1 Package(s)

Total size: 94 k
Installed size: 94 k
Is this ok [y/N]: y
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Installing : irods-eudat-b2safe-dpm-client-1.0-0.noarch                                                                                              1/1

To install/configure b2safe dpm client in iRODS do following as the user who runs iRODS :

source /etc/irods/service_account.config
su - $IRODS_SERVICE_ACCOUNT_NAME
cd /opt/eudat/b2safe-dpm-client/conf
# update config.ini with correct parameters with your favorite editor

  Verifying  : irods-eudat-b2safe-dpm-client-1.0-0.noarch                                                                                              1/1

Installed:
  irods-eudat-b2safe-dpm-client.noarch 0:1.0-0

Complete!
```

